### PR TITLE
Add an alternative tempest user and project

### DIFF
--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -10,14 +10,25 @@
 cumulus_projects:
   - "{{ cumulus_demo_project }}"
   - "{{ cumulus_euclid_project }}"
-  - "{{ cumulus_tempest_project }}"
   - "{{ cumulus_services_project }}"
+  - "{{ cumulus_tempest_project }}"
+  - "{{ cumulus_tempest_alt_project }}"
 
 # Definition of the cumulus demo project. Format is as required by the
 # stackhpc.os-projects role.
 cumulus_demo_project:
   name: demo
   description: Cumulus @ Cambridge demo project
+  project_domain: default
+  user_domain: default
+  users: "{{ cumulus_resops_users }}"
+  quotas: "{{ cumulus_unlimited_quotas }}"
+
+# Definition of the cumulus service project. Format is as required by the
+# stackhpc.os-projects role.
+cumulus_services_project:
+  name: services
+  description: services e.g refstack web-app 
   project_domain: default
   user_domain: default
   users: "{{ cumulus_resops_users }}"
@@ -43,14 +54,24 @@ cumulus_tempest_project:
       roles: "{{ cumulus_user_roles }}"
   quotas: "{{ cumulus_unlimited_quotas }}"
 
-# Definition of the cumulus service project. Format is as required by the
+# Definition of the cumulus tempest-alt project. Format is as required by the
 # stackhpc.os-projects role.
-cumulus_services_project:
-  name: services
-  description: services e.g refstack web-app 
+cumulus_tempest_alt_project:
+  name: tempest-alt
+  description: alternative tempest project to test isolation
   project_domain: default
   user_domain: default
-  users: "{{ cumulus_resops_users }}"
+  users:
+    - name: tempest-alt
+      password: !vault |
+        $ANSIBLE_VAULT;1.1;AES256
+        35363833646639633139383033643566366563646639326139643331393863323563336236383336
+        3737643662666638316230663731326635643762623436310a326264623063646537653135663565
+        61356666393939366564646663626331343263643433663864656365376430376435646237623939
+        3937633836613266350a303766663064396162626363376437343231636437336466353062363131
+        38613366396631373764316166613135616637373537636538343931303436666438656539613665
+        3938376661303265373930386530313033656231363638353435
+      roles: "{{ cumulus_user_roles }}"
   quotas: "{{ cumulus_unlimited_quotas }}"
 
 # List of users in the cumulus ResOps team. Format is as required by the


### PR DESCRIPTION
from the tempest manual:

     To make sure you don’t have a credentials starvation issue when running in
     parallel make sure you have at least two times the number of worker processes
     you are using to execute Tempest available in the file. (If running serially the
     worker count is 1.)

     It is worth pointing out that each set of credentials in the accounts.yaml
     should have a unique project. This is required to provide proper isolation to
     the tests using the credentials, and failure to do this will likely cause
     unexpected failures in some tests.

https://docs.openstack.org/tempest/latest/configuration.html#pre-provisioned-credentials