### PR TITLE
Add an router from cumulus-internal -> ilab

### DIFF
--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -182,6 +182,9 @@ cumulus_subnet_internal:
   dns_nameservers:
     - 131.111.8.42
     - 131.111.12.20
+  host_routes:
+    - destination: "{{ cumulus_subnet_external.cidr }}"
+      nexthop: 10.218.0.2
 
 # cumulus inspection network name.
 cumulus_network_inspection_name: "inspection-net"
@@ -356,6 +359,7 @@ cumulus_subnet_infiniband:
 cumulus_routers:
   - "{{ cumulus_router_internet }}"
   - "{{ cumulus_router_demo }}"
+  - "{{ cumulus_router_internal_to_ilab }}"
 
 cumulus_router_internet:
   - name: "internal-to-internet"
@@ -409,6 +413,16 @@ cumulus_router_demo:
       - "{{ cumulus_network_demo_vxlan_name }}"
       #- "{{ cumulus_network_demo_hs_vlan_name }}"
       #- "{{ cumulus_network_demo_provider_name }}"
+    network: "{{ cumulus_network_ilab_name }}"
+
+# Connects the internal network to ilab
+cumulus_router_internal_to_ilab:
+  - name: internal-to-ilab
+    project: admin
+    interfaces:
+      - net: "{{ cumulus_network_internal_name }}"
+        subnet: "{{ cumulus_network_internal_name }}"
+        portip: "10.218.0.2"
     network: "{{ cumulus_network_ilab_name }}"
 
 # List of security groups in the cumulus demo project. Format is as required by the


### PR DESCRIPTION
Tempest is currently using the cumulus-internal network as it's tenant
network. I thought it would be better if floatings ips were assigned
on the ilab network - rather than an internet facing one.