### PR TITLE
Enable Nigel Hambly (Gaia) in federation mapping

### DIFF
--- a/federation_mapping.json
+++ b/federation_mapping.json
@@ -35,7 +35,8 @@
                     "daniela.bauer@imperial.ac.uk",
                     "simon.fayer05@imperial.ac.uk",
                     "daniela.bauer.grid@googlemail.com",
-                    "markholliman@gmail.com"
+                    "markholliman@gmail.com",
+                    "nigelhambly@googlemail.com"
                 ]
             }
         ]


### PR DESCRIPTION
Gaia user Nigel Hambly white-listing in Keycloak federation mapping.