### PR TITLE
Merge configuration for Ironic on the overcloud

### DIFF
--- a/ansible/cumulus.yml
+++ b/ansible/cumulus.yml
@@ -4,4 +4,4 @@
 - include: cumulus-networks.yml
 - include: cumulus-flavors.yml
 - include: cumulus-images.yml
-- include: cumulus-container-clusters.yml
+#- include: cumulus-container-clusters.yml

--- a/ansible/cumulus.yml
+++ b/ansible/cumulus.yml
@@ -4,4 +4,4 @@
 - include: cumulus-networks.yml
 - include: cumulus-flavors.yml
 - include: cumulus-images.yml
-#- include: cumulus-container-clusters.yml
+- include: cumulus-container-clusters.yml

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -327,6 +327,7 @@ cumulus_subnet_inspection:
 
 cumulus_routers:
   - "{{ cumulus_router_demo }}"
+  - "{{ cumulus_router_provider_218 }}"
   - "{{ cumulus_router_provision }}"
   - "{{ cumulus_router_cleaning }}"
   - "{{ cumulus_router_inspection }}"
@@ -336,6 +337,13 @@ cumulus_router_demo:
     project: "{{ cumulus_demo_project.name }}"
     interfaces:
       - "{{ cumulus_network_demo_vxlan_name }}"
+    network: "{{ cumulus_network_internet_name }}"
+
+cumulus_router_provider_218:
+  - name: "provider-218-router"
+    project: "admin"
+    interfaces:
+      - "{{ cumulus_network_provider_name }}"
     network: "{{ cumulus_network_internet_name }}"
 
 cumulus_router_provision:
@@ -492,16 +500,16 @@ cumulus_images:
   - "{{ cumulus_openSUSE_leap_15 }}"
 
 cumulus_fedora_atomic_29:
-  name: "FedoraAtomic29-20190429"
-  image_url: "https://ftp.icm.edu.pl/pub/Linux/dist/fedora-alt/atomic/stable/Fedora-29-updates-20190429.0/AtomicHost/x86_64/images/Fedora-AtomicHost-29-20190429.0.x86_64.qcow2"
+  name: "FedoraAtomic29-20190820"
+  image_url: "https://dl.fedoraproject.org/pub/alt/atomic/stable/Fedora-29-updates-20190820.0/AtomicHost/x86_64/images/Fedora-AtomicHost-29-20190820.0.x86_64.qcow2"
   properties:
     os_type: "linux"
     os_distro: "fedora-atomic"
     os_version: "29"
 
 cumulus_centos_7:
-  name: "CentOS7-1901"
-  image_url: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1901.qcow2"
+  name: "CentOS7-1907"
+  image_url: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1907.qcow2"
   properties:
     os_type: "linux"
     os_distro: "centos"
@@ -520,12 +528,12 @@ cumulus_cirros:
     os_version: "0.4.0"
 
 cumulus_debian_9:
-  name: "Debian-Stretch-9.9.4"
-  image_url: "https://cdimage.debian.org/cdimage/cloud/OpenStack/current-9/debian-9-openstack-amd64.qcow2"
+  name: "Debian-Stretch-9.11.0"
+  image_url: "https://cdimage.debian.org/cdimage/openstack/9.11.0/debian-9.11.0-openstack-amd64.qcow2"
   properties:
     os_type: "linux"
     os_distro: "debian"
-    os_version: "9.9.4"
+    os_version: "9.11.0"
 
 cumulus_fedora_30:
   name: "Fedora-30-1.2"
@@ -536,8 +544,8 @@ cumulus_fedora_30:
     os_version: "30"
 
 cumulus_ubuntu_18_04:
-  name: "Ubuntu-Bionic-18.04-20190718"
-  image_url: "https://cloud-images.ubuntu.com/bionic/20190718/bionic-server-cloudimg-amd64.img"
+  name: "Ubuntu-Bionic-18.04-20190905"
+  image_url: "https://cloud-images.ubuntu.com/bionic/20190905/bionic-server-cloudimg-amd64.img"
   properties:
     os_type: "linux"
     os_distro: "ubuntu"
@@ -637,7 +645,7 @@ cumulus_container_clusters_template_swarm_fedora_atomic_27:
   external_network: "{{ cumulus_network_ilab_name }}"
   master_flavor: "{{ cumulus_flavor_general_tiny.name }}"
   flavor: "{{ cumulus_flavor_general_small.name }}"
-  image: "FedoraAtomic29-20190429"
+  image: "FedoraAtomic29-20190820"
   name: "swarm"
   coe: "swarm-mode"
   network_driver: "docker"
@@ -647,12 +655,12 @@ cumulus_container_clusters_template_swarm_fedora_atomic_27:
 cumulus_container_clusters_template_k8s_14:
   public:
   floating-ip-disabled:
-  labels: "cgroup_driver=cgroupfs,prometheus_monitoring=true,kube_tag=v1.14.3,cloud_provider_tag=v1.14.0"
+  labels: "cgroup_driver=cgroupfs,ingress_controller=traefik,prometheus_monitoring=false,heat_container_agnet_tag=stein-stable,kube_tag=v1.14.6,cloud_provider_tag=v1.14.0"
   external_network: "{{ cumulus_network_ilab_name }}"
   master_flavor: "{{ cumulus_flavor_general_tiny.name }}"
   flavor: "{{ cumulus_flavor_general_small.name }}"
-  image: "FedoraAtomic29-20190429"
-  name: "kubernetes-1.14.3"
+  image: "FedoraAtomic29-20190820"
+  name: "kubernetes-1.14.6"
   coe: "kubernetes"
   network_driver: "flannel"
   docker_storage_driver: "overlay2"
@@ -661,12 +669,12 @@ cumulus_container_clusters_template_k8s_14:
 cumulus_container_clusters_template_k8s_15:
   public:
   floating-ip-disabled:
-  labels: "cgroup_driver=cgroupfs,prometheus_monitoring=true,kube_tag=v1.15.0,cloud_provider_tag=v1.15.0"
+  labels: "cgroup_driver=cgroupfs,ingress_controller=traefik,prometheus_monitoring=false,heat_container_agnet_tag=stein-stable,kube_tag=v1.15.3,cloud_provider_tag=v1.15.0"
   external_network: "{{ cumulus_network_ilab_name }}"
   master_flavor: "{{ cumulus_flavor_general_tiny.name }}"
   flavor: "{{ cumulus_flavor_general_small.name }}"
-  image: "FedoraAtomic29-20190429"
-  name: "kubernetes-1.15.0"
+  image: "FedoraAtomic29-20190820"
+  name: "kubernetes-1.15.3"
   coe: "kubernetes"
   network_driver: "flannel"
   docker_storage_driver: "overlay2"

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -198,14 +198,13 @@ cumulus_networks:
   - "{{ cumulus_network_ilab }}"
   - "{{ cumulus_network_internal }}"
   - "{{ cumulus_network_demo_vxlan }}"
-  - "{{ cumulus_network_inspection }}"
 
 cumulus_network_internet_name: "internet"
 cumulus_network_internet:
   name: "{{ cumulus_network_internet_name }}"
   project: "admin"
   provider_network_type: "vlan"
-  provider_physical_network: "physnet2"
+  provider_physical_network: "physnet1"
   provider_segmentation_id: 111
   shared: false
   external: true
@@ -228,7 +227,7 @@ cumulus_network_ilab:
   name: "{{ cumulus_network_ilab_name }}"
   project: "admin"
   provider_network_type: "vlan"
-  provider_physical_network: "physnet2"
+  provider_physical_network: "physnet1"
   provider_segmentation_id: 319
   shared: false
   external: true
@@ -250,9 +249,9 @@ cumulus_network_internal:
   name: "{{ cumulus_network_internal_name }}"
   project: "admin"
   provider_network_type: "vlan"
-  provider_physical_network: "physnet2"
+  provider_physical_network: "physnet1"
   provider_segmentation_id: 305
-  shared: true
+  shared: false
   external: false
   subnets:
     - "{{ cumulus_subnet_internal }}"
@@ -284,68 +283,6 @@ cumulus_subnet_demo_vxlan:
   allocation_pool_end: "10.1.0.254"
   dns_nameservers:
     - 8.8.8.8
-
-# cumulus inspection network name.
-cumulus_network_inspection_name: "inspection_net"
-
-# cumulus inspection network.
-cumulus_network_inspection:
-  name: "{{ cumulus_network_inspection_name }}"
-  project: "admin"
-  provider_network_type: "vlan"
-  provider_physical_network: "physnet1"
-  provider_segmentation_id: 310
-  shared: false
-  # Subnet configuration.
-  subnets:
-    - "{{ cumulus_subnet_inspection }}"
-
-# cumulus inspection subnet.
-cumulus_subnet_inspection:
-  name: "{{ cumulus_network_inspection_name }}"
-  project: "admin"
-  cidr: "10.230.0.0/16"
-  enable_dhcp: false
-  allocation_pool_start: "10.230.0.1"
-  allocation_pool_end: "10.230.0.1"
-
-cumulus_routers:
-  - "{{ cumulus_router_provision }}"
-  - "{{ cumulus_router_cleaning }}"
-  - "{{ cumulus_router_inspection }}"
-
-cumulus_router_provision:
-  - name: "provision_wl"
-    project: "admin"
-    interfaces:
-      - net: "{{ cumulus_network_internal_name }}"
-        subnet: "{{ cumulus_network_internal_name }}"
-        portip: "10.225.0.2"
-      - net: "provision_wl_net"
-        subnet: "provision_wl_net"
-        portip: "10.231.0.1"
-
-cumulus_router_cleaning:
-  - name: "cleaning"
-    project: "admin"
-    interfaces:
-      - net: "{{ cumulus_network_internal_name }}"
-        subnet: "{{ cumulus_network_internal_name }}"
-        portip: "10.225.0.3"
-      - net: "cleaning_net"
-        subnet: "cleaning_net"
-        portip: "10.233.0.1"
-
-cumulus_router_inspection:
-  - name: "inspection"
-    project: "admin"
-    interfaces:
-      - net: "{{ cumulus_network_internal_name }}"
-        subnet: "{{ cumulus_network_internal_name }}"
-        portip: "10.225.0.4"
-      - net: "inspection_net"
-        subnet: "inspection_net"
-        portip: "10.230.0.1"
 
 # List of security groups in the cumulus demo project. Format is as required by the
 # stackhpc.os-networks role.

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -198,6 +198,7 @@ cumulus_networks:
   - "{{ cumulus_network_ilab }}"
   - "{{ cumulus_network_internal }}"
   - "{{ cumulus_network_demo_vxlan }}"
+  - "{{ cumulus_network_inspection }}"
 
 cumulus_network_internet_name: "internet"
 cumulus_network_internet:
@@ -284,8 +285,68 @@ cumulus_subnet_demo_vxlan:
   dns_nameservers:
     - 8.8.8.8
 
+# cumulus inspection network name.
+cumulus_network_inspection_name: "inspection-net"
+
+# cumulus inspection network.
+cumulus_network_inspection:
+  name: "{{ cumulus_network_inspection_name }}"
+  project: "admin"
+  provider_network_type: "vlan"
+  provider_physical_network: "physnet1"
+  provider_segmentation_id: 310
+  shared: false
+  # Subnet configuration.
+  subnets:
+    - "{{ cumulus_subnet_inspection }}"
+
+# cumulus inspection subnet.
+cumulus_subnet_inspection:
+  name: "{{ cumulus_network_inspection_name }}"
+  project: "admin"
+  cidr: "10.230.0.0/16"
+  enable_dhcp: false
+  allocation_pool_start: "10.230.0.1"
+  allocation_pool_end: "10.230.0.1"
+
 cumulus_routers:
   - "{{ cumulus_router_demo }}"
+  - "{{ cumulus_router_provision }}"
+  - "{{ cumulus_router_cleaning }}"
+  - "{{ cumulus_router_inspection }}"
+
+cumulus_router_provision:
+  - name: "provision-router"
+    project: "admin"
+    interfaces:
+      - net: "{{ cumulus_network_internal_name }}"
+        subnet: "{{ cumulus_network_internal_name }}"
+        portip: "10.225.0.2"
+      - net: "provision-net"
+        subnet: "provision-net"
+        portip: "10.231.0.1"
+
+cumulus_router_cleaning:
+  - name: "cleaning-router"
+    project: "admin"
+    interfaces:
+      - net: "{{ cumulus_network_internal_name }}"
+        subnet: "{{ cumulus_network_internal_name }}"
+        portip: "10.225.0.3"
+      - net: "cleaning-net"
+        subnet: "cleaning-net"
+        portip: "10.233.0.1"
+
+cumulus_router_inspection:
+  - name: "inspection-router"
+    project: "admin"
+    interfaces:
+      - net: "{{ cumulus_network_internal_name }}"
+        subnet: "{{ cumulus_network_internal_name }}"
+        portip: "10.225.0.4"
+      - net: "inspection-net"
+        subnet: "inspection-net"
+        portip: "10.230.0.1"
 
 cumulus_router_demo:
   - name: "{{ cumulus_demo_project.name }}"

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -628,8 +628,8 @@ cumulus_systemd_modules_load_ipoib: |
 
 cumulus_container_clusters_templates:
   - "{{ cumulus_container_clusters_template_swarm_fedora_atomic_27 }}"
-  - "{{ cumulus_container_clusters_template_k8s_13 }}"
   - "{{ cumulus_container_clusters_template_k8s_14 }}"
+  - "{{ cumulus_container_clusters_template_k8s_15 }}"
 
 cumulus_container_clusters_template_swarm_fedora_atomic_27:
   public:
@@ -644,29 +644,29 @@ cumulus_container_clusters_template_swarm_fedora_atomic_27:
   docker_storage_driver: "overlay2"
   server_type: "vm"
 
-cumulus_container_clusters_template_k8s_13:
+cumulus_container_clusters_template_k8s_14:
   public:
   floating-ip-disabled:
-  labels: "cgroup_driver=cgroupfs,prometheus_monitoring=true,kube_tag=v1.13.5,cloud_provider_tag=1.13.1"
+  labels: "cgroup_driver=cgroupfs,prometheus_monitoring=true,kube_tag=v1.14.3,cloud_provider_tag=v1.14.0"
   external_network: "{{ cumulus_network_ilab_name }}"
   master_flavor: "{{ cumulus_flavor_general_tiny.name }}"
   flavor: "{{ cumulus_flavor_general_small.name }}"
   image: "FedoraAtomic29-20190429"
-  name: "kubernetes-1.13"
+  name: "kubernetes-1.14.3"
   coe: "kubernetes"
   network_driver: "flannel"
   docker_storage_driver: "overlay2"
   server_type: "vm"
 
-cumulus_container_clusters_template_k8s_14:
+cumulus_container_clusters_template_k8s_15:
   public:
   floating-ip-disabled:
-  labels: "cgroup_driver=cgroupfs,prometheus_monitoring=true,kube_tag=v1.14.1,cloud_provider_tag=1.14.0"
+  labels: "cgroup_driver=cgroupfs,prometheus_monitoring=true,kube_tag=v1.15.0,cloud_provider_tag=v1.15.0"
   external_network: "{{ cumulus_network_ilab_name }}"
   master_flavor: "{{ cumulus_flavor_general_tiny.name }}"
   flavor: "{{ cumulus_flavor_general_small.name }}"
   image: "FedoraAtomic29-20190429"
-  name: "kubernetes-1.14"
+  name: "kubernetes-1.15.0"
   coe: "kubernetes"
   network_driver: "flannel"
   docker_storage_driver: "overlay2"

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -195,6 +195,7 @@ cumulus_unlimited_quotas:
 # stackhpc.os-networks role.
 cumulus_networks:
   - "{{ cumulus_network_internet }}"
+  - "{{ cumulus_network_provider }}"
   - "{{ cumulus_network_ilab }}"
   - "{{ cumulus_network_internal }}"
   - "{{ cumulus_network_demo_vxlan }}"
@@ -219,6 +220,28 @@ cumulus_subnet_internet:
   allocation_pool_start: "128.232.224.84"
   allocation_pool_end: "128.232.224.91"
   enable_dhcp: false
+  dns_nameservers:
+    - 131.111.8.42
+    - 131.111.12.20
+
+cumulus_network_provider_name: "provider-318"
+cumulus_network_provider:
+  name: "{{ cumulus_network_provider_name }}"
+  project: "admin"
+  provider_network_type: "vlan"
+  provider_physical_network: "physnet1"
+  provider_segmentation_id: 318
+  shared: true
+  external: false
+  subnets:
+    - "{{ cumulus_subnet_provider }}"
+cumulus_subnet_provider:
+  name: "{{ cumulus_network_provider_name }}"
+  project: "admin"
+  cidr: "10.238.0.0/16"
+  gateway_ip: "10.238.0.1"
+  allocation_pool_start: "10.238.215.100"
+  allocation_pool_end: "10.238.215.199"
   dns_nameservers:
     - 131.111.8.42
     - 131.111.12.20

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -395,6 +395,7 @@ cumulus_flavors:
   - "{{ cumulus_flavor_general_medium }}"
   - "{{ cumulus_flavor_general_small }}"
   - "{{ cumulus_flavor_general_tiny }}"
+  - "{{ cumulus_flavor_baremetal_general }}"
 
 cumulus_flavor_general_xlarge:
   name: "general.v1.xlarge"
@@ -447,8 +448,8 @@ cumulus_flavor_general_tiny:
 cumulus_flavor_baremetal_general:
   name: "bm.general"
   ram: 196608
-  disk: 480
-  vcpus: 64
+  disk: 100
+  vcpus: 32
   extra_specs:
     "resources:CUSTOM_BAREMETAL_A": 1
     "resources:VCPU": 0

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -284,6 +284,16 @@ cumulus_subnet_demo_vxlan:
   dns_nameservers:
     - 8.8.8.8
 
+cumulus_routers:
+  - "{{ cumulus_router_demo }}"
+
+cumulus_router_demo:
+  - name: "{{ cumulus_demo_project.name }}"
+    project: "{{ cumulus_demo_project.name }}"
+    interfaces:
+      - "{{ cumulus_network_demo_vxlan_name }}"
+    network: "{{ cumulus_network_internet_name }}"
+
 # List of security groups in the cumulus demo project. Format is as required by the
 # stackhpc.os-networks role.
 # FIXME: Security group rules cannot be assigned to another project, due to

--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -253,16 +253,15 @@ cumulus_network_internal:
   provider_physical_network: "physnet1"
   provider_segmentation_id: 305
   shared: false
-  external: false
   subnets:
     - "{{ cumulus_subnet_internal }}"
 cumulus_subnet_internal:
   name: "{{ cumulus_network_internal_name }}"
   project: "admin"
   cidr: "10.225.0.0/16"
-  gateway_ip: "10.225.1.0"
-  allocation_pool_start: "10.225.10.1"
-  allocation_pool_end: "10.225.10.199"
+  enable_dhcp: false
+  allocation_pool_start: "10.225.0.2"
+  allocation_pool_end: "10.225.0.4"
   dns_nameservers:
     - 131.111.8.42
     - 131.111.12.20
@@ -285,10 +284,7 @@ cumulus_subnet_demo_vxlan:
   dns_nameservers:
     - 8.8.8.8
 
-# cumulus inspection network name.
 cumulus_network_inspection_name: "inspection-net"
-
-# cumulus inspection network.
 cumulus_network_inspection:
   name: "{{ cumulus_network_inspection_name }}"
   project: "admin"
@@ -296,11 +292,8 @@ cumulus_network_inspection:
   provider_physical_network: "physnet1"
   provider_segmentation_id: 310
   shared: false
-  # Subnet configuration.
   subnets:
     - "{{ cumulus_subnet_inspection }}"
-
-# cumulus inspection subnet.
 cumulus_subnet_inspection:
   name: "{{ cumulus_network_inspection_name }}"
   project: "admin"
@@ -314,6 +307,13 @@ cumulus_routers:
   - "{{ cumulus_router_provision }}"
   - "{{ cumulus_router_cleaning }}"
   - "{{ cumulus_router_inspection }}"
+
+cumulus_router_demo:
+  - name: "{{ cumulus_demo_project.name }}"
+    project: "{{ cumulus_demo_project.name }}"
+    interfaces:
+      - "{{ cumulus_network_demo_vxlan_name }}"
+    network: "{{ cumulus_network_internet_name }}"
 
 cumulus_router_provision:
   - name: "provision-router"
@@ -347,13 +347,6 @@ cumulus_router_inspection:
       - net: "inspection-net"
         subnet: "inspection-net"
         portip: "10.230.0.1"
-
-cumulus_router_demo:
-  - name: "{{ cumulus_demo_project.name }}"
-    project: "{{ cumulus_demo_project.name }}"
-    interfaces:
-      - "{{ cumulus_network_demo_vxlan_name }}"
-    network: "{{ cumulus_network_internet_name }}"
 
 # List of security groups in the cumulus demo project. Format is as required by the
 # stackhpc.os-networks role.


### PR DESCRIPTION
This PR contains configuration to create the Overcloud Neutron routers and networks for the logically separated Ironic service networks deployed by Kayobe.

It also provisions a baremetal flavor corresponding to a Skylake compute node and a provider VLAN for shared access for Ironic nodes.