### PR TITLE
Update flavor to match available disc space.

### DIFF
--- a/etc/cumulus-config/cumulus-config.yml
+++ b/etc/cumulus-config/cumulus-config.yml
@@ -1006,7 +1006,7 @@ cumulus_flavor_gaia_cclake_54vcpu:
   vcpus: 54
   ram: 94208
   disk: 20
-  ephemeral: 420
+  ephemeral: 380
   is_public: false
 
 cumulus_flavor_gaia_cclake_26vcpu:
@@ -1014,7 +1014,7 @@ cumulus_flavor_gaia_cclake_26vcpu:
   vcpus: 26
   ram: 47104
   disk: 20
-  ephemeral: 200
+  ephemeral: 180
   is_public: false
 
 cumulus_flavor_gaia_cclake_12vcpu:
@@ -1022,7 +1022,7 @@ cumulus_flavor_gaia_cclake_12vcpu:
   vcpus: 12
   ram: 22528
   disk: 20
-  ephemeral: 90
+  ephemeral: 80
   is_public: false
 
 cumulus_flavor_gaia_cclake_6vcpu:
@@ -1030,7 +1030,7 @@ cumulus_flavor_gaia_cclake_6vcpu:
   vcpus: 6
   ram: 10240
   disk: 20
-  ephemeral: 35
+  ephemeral: 30
   is_public: false
 
 cumulus_flavor_gaia_cclake_2vcpu:


### PR DESCRIPTION
Fix for issue #69. Update the Cascade lake flavors to match available disc space (assumed 880G, actual is 830G).